### PR TITLE
Update URL for Authorize.net

### DIFF
--- a/modules/gateway/Authorize/gateway.class.php
+++ b/modules/gateway/Authorize/gateway.class.php
@@ -12,7 +12,7 @@ class Gateway {
 
 		$this->_module	= $module;
 		$this->_basket =& $GLOBALS['cart']->basket;
-		$this->_url			= $this->_module['testMode'] ? 'test.authorize.net' : 'secure.authorize.net';
+		$this->_url			= $this->_module['testMode'] ? 'test.authorize.net' : 'secure2.authorize.net';
 		$this->_path		= '/gateway/transact.dll';
 		$this->_aim_delimiter = '|';
 	}


### PR DESCRIPTION
 Authorize.net is updating some of their requirements for PCI compliance including the use of Akamai SureRoute.  There are three new URLs that they would like people to use to interact with Authorize.net.  secure.authorize.net/gateway/transact.dll will remain valid, at least for a while, but it is recommended to update this URL to secure2.authorize.net/gateway/transact.dll.

Additional Details can be found here: http://www.authorize.net/support/akamaifaqs/?utm_campaign=February%202016%20Technical%20Updates%20for%20Merchants.html&utm_medium=email&utm_source=Eloqua#newurls
